### PR TITLE
Adds access to the record in the validator.

### DIFF
--- a/lib/password_strength/active_record/ar2.rb
+++ b/lib/password_strength/active_record/ar2.rb
@@ -47,7 +47,7 @@ module PasswordStrength
       validates_each(attr_names, options) do |record, attr_name, value|
         next unless PasswordStrength.enabled
 
-        strength = options[:using].new(record.send(options[:with]), value, :exclude => options[:exclude])
+        strength = options[:using].new(record.send(options[:with]), value, :exclude => options[:exclude], :record => record)
         strength.test
         record.errors.add(attr_name, :too_weak, options) unless strength.valid?(options[:level])
       end

--- a/lib/password_strength/active_record/ar3.rb
+++ b/lib/password_strength/active_record/ar3.rb
@@ -7,7 +7,7 @@ module ActiveModel # :nodoc:
 
       def validate_each(record, attribute, value)
         return unless PasswordStrength.enabled
-        strength = options[:using].new(record.send(options[:with]), value, :exclude => options[:exclude])
+        strength = options[:using].new(record.send(options[:with]), value, :exclude => options[:exclude], :record => record)
         strength.test
         record.errors.add(attribute, :too_weak, options) unless PasswordStrength.enabled && strength.valid?(options[:level])
       end

--- a/lib/password_strength/base.rb
+++ b/lib/password_strength/base.rb
@@ -21,6 +21,8 @@ module PasswordStrength
     # The current test status. Can be +:weak+, +:good+, +:strong+ or +:invalid+.
     attr_reader   :status
 
+    attr_reader   :record
+
     # Set what characters cannot be present on password.
     # Can be a regular expression or array.
     #
@@ -42,6 +44,7 @@ module PasswordStrength
       @password = password.to_s
       @score = 0
       @exclude = options[:exclude]
+      @record = options[:record]
     end
 
     # Check if the password has the specified score.

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,6 +1,13 @@
 # -*- encoding: utf-8 -*-
 require "test_helper"
 
+class PasswordStrengthTester < PasswordStrength::Base
+  def test
+    record.username = 'bar'
+    good!
+  end
+end
+
 class TestActiveRecord < Test::Unit::TestCase
   def setup
     PasswordStrength.enabled = true
@@ -81,5 +88,15 @@ class TestActiveRecord < Test::Unit::TestCase
     PasswordStrength.enabled = false
     @user.update_attributes :password => ""
     assert @user.valid?
+  end
+
+  def test_record_access_from_validator
+    User.validates_strength_of :password, :using => PasswordStrengthTester
+    @user.username = 'foo'
+    @user.password = 'foo'
+
+    assert @user.username, 'foo'
+    @user.valid?
+    assert @user.username, 'bar'
   end
 end


### PR DESCRIPTION
We wanted to check password strength against more than just the username (or other supplied) field. Because we have several models that we want to validate, we needed access to the record in the validator. This allows us to check the class of the object, and check against relevant fields accordingly.

This may not follow your vision for the gem, but it works for us.

Wrote a test as well, it does the job although it's far from perfect. It tests by setting a field value inside the validator, which is of course not done in production code, but as a test case it seems to work.

Happy to answer any questions or concerns you have,
Cheers
