### PR TITLE
Unify score for too short passwords

### DIFF
--- a/app/assets/javascripts/password_strength.js
+++ b/app/assets/javascripts/password_strength.js
@@ -65,7 +65,7 @@ var PasswordStrength = (function(){
 
     switch (name) {
       case "password_size":
-        if (this.password.length < 4) {
+        if (this.password.length < 6) {
           score = -100;
         } else {
           score = this.password.length * 4;


### PR DESCRIPTION
It's 6 in the ruby class so it makes sense to follow the same rules in js.
