### PR TITLE
Change hard dependency from ActiveRecord to ActiveModel.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     password_strength (1.0.1)
-      activerecord
+      activemodel
 
 GEM
   remote: http://rubygems.org/
@@ -56,6 +56,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord
   password_strength!
   pry-meta
   rake

--- a/password_strength.gemspec
+++ b/password_strength.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "activerecord"
+  s.add_dependency "activemodel"
 
+  s.add_development_dependency "activerecord"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry-meta"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Since support for old versions of ActiveRecord was removed there's no need for a hard dependency on ActiveRecord anymore (and removing it makes things easier for those of us not using it).

It may also be a good idea to change "ActiveRecord" to "ActiveModel" in the gem description, but I didn't want to be presumptuous. :smile: 
