### PR TITLE
Include missing symbol in javascript special character regex

### DIFF
--- a/app/assets/javascripts/password_strength.js
+++ b/app/assets/javascripts/password_strength.js
@@ -1,8 +1,8 @@
 (function(){
   var MULTIPLE_NUMBERS_RE = /\d.*?\d.*?\d/;
-  var MULTIPLE_SYMBOLS_RE = /[!@#$%^&*?_~].*?[!@#$%^&*?_~]/;
+  var MULTIPLE_SYMBOLS_RE = /[!@#$%^&*?_~-].*?[!@#$%^&*?_~-]/;
   var UPPERCASE_LOWERCASE_RE = /([a-z].*[A-Z])|([A-Z].*[a-z])/;
-  var SYMBOL_RE = /[!@#\$%^&*?_~]/;
+  var SYMBOL_RE = /[!@#\$%^&*?_~-]/;
 
   function escapeForRegexp(string) {
     return (string || "").replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");

--- a/lib/password_strength/active_model.rb
+++ b/lib/password_strength/active_model.rb
@@ -12,7 +12,7 @@ module ActiveModel # :nodoc:
           :record => record
         )
         strength.test
-        record.errors.add(attribute, :too_weak, options) unless PasswordStrength.enabled && strength.valid?(level(record))
+        record.errors.add(attribute, :too_weak, **options) unless PasswordStrength.enabled && strength.valid?(level(record))
       end
 
       def check_validity!

--- a/lib/password_strength/version.rb
+++ b/lib/password_strength/version.rb
@@ -2,7 +2,7 @@ module PasswordStrength
   module Version # :nodoc: all
     MAJOR = 1
     MINOR = 1
-    PATCH = 4
+    PATCH = 5
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}"
   end
 end

--- a/test/password_strength_test.js
+++ b/test/password_strength_test.js
@@ -212,6 +212,11 @@ QUnit.test("reward password that contains symbols and chars", function(assert) {
   assert.equal(strength.scoreFor("symbols_chars"), 15);
 });
 
+QUnit.test("reward password that contains '-' symbol and chars", function(assert) {
+  strength.password = "a-";
+  assert.equal(strength.scoreFor("symbols_chars"), 15);
+});
+
 QUnit.test("detect two-chars repetitions", function(assert) {
   assert.equal(strength.repetitions("11221122", 2), 3);
 });


### PR DESCRIPTION
Javascript regex for symbols was missing -, which is present in the ruby implementation, thus yielding different scores.